### PR TITLE
Error running L38 with python 3.6.3

### DIFF
--- a/python/projection_demo.py
+++ b/python/projection_demo.py
@@ -145,7 +145,7 @@ plt.xlabel('tangential')
 plt.ylabel('plane')
 plt.subplot(1,3,3)
 plt.plot(seg_array[middle_slice,0,:])
-plt.plot(seg_array[middle_slice,proj_data_info.get_num_views()/2,:])
+plt.plot(seg_array[middle_slice,int(proj_data_info.get_num_views()/2),:])
 plt.title('Horizontal profiles\n(middle sinogram)');
 plt.legend(('first view', 'middle view'));
 #%% display all sinograms in a (repeated) loop
@@ -189,7 +189,7 @@ plt.clim(0,maxforplot);
 #%% For this experiment, we will use a larger cylinder in the centre
 length=60
 radius=200
-middle_slice=(image_data.get_max_z()+image_data.get_min_z())/2
+middle_slice=int((image_data.get_max_z()+image_data.get_min_z())/2)
 z_centre=middle_slice*image_data.get_voxel_size().z()
 centre=stir.FloatCartesianCoordinate3D(z_centre,0,0)
 shape=stir.EllipsoidalCylinder(length, radius, radius,

--- a/python/projection_demo.py
+++ b/python/projection_demo.py
@@ -74,7 +74,7 @@ projdataout=stir.ProjDataInMemory(exam_info, proj_data_info);
 # choice of origin (the middle of the first ring).
 length=60
 radius=40
-middle_slice=(image_data.get_max_z()+image_data.get_min_z())/2
+middle_slice=int((image_data.get_max_z()+image_data.get_min_z())/2)
 z_centre=middle_slice*image_data.get_voxel_size().z()
 # create a coordinate for the centre (note the z,y,x order)
 centre=stir.FloatCartesianCoordinate3D(z_centre,0,0)

--- a/python/projection_demo.py
+++ b/python/projection_demo.py
@@ -32,7 +32,7 @@ print(scanner.parameter_info())
 span=3;
 max_ring_diff=1;
 # use default number of "views" (or "azimutal angles")
-num_views=scanner.get_num_detectors_per_ring()/2;
+num_views=int(scanner.get_num_detectors_per_ring()/2);
 # construct the object using ProjDataInfoCTI
 # (the naming of this function was related to the scanner manufacturer, but will be changed in the future)
 proj_data_info=stir.ProjDataInfo.ProjDataInfoCTI(scanner,


### PR DESCRIPTION
I ran into an error with executing this line on my mac - Python 3.6.3

https://github.com/UCL/STIR-exercises/blob/e5ab1f58baa9d477a538c96a88da59e0e9256001/python/projection_demo.py#L38-L40
produced the error:

> NotImplementedError: Wrong number or type of arguments for overloaded function 'ProjDataInfo_ProjDataInfoCTI'.
>   Possible C/C++ prototypes are:
>     stir::ProjDataInfo::ProjDataInfoCTI(stir::shared_ptr< stir::Scanner > const &,int const,int const,int const,int const,bool const)
>     stir::ProjDataInfo::ProjDataInfoCTI(stir::shared_ptr< stir::Scanner > const &,int const,int const,int const,int const)

I believe this is because https://github.com/UCL/STIR-exercises/blob/e5ab1f58baa9d477a538c96a88da59e0e9256001/python/projection_demo.py#L35 produces type float where `stir::ProjDataInfo::ProjDataInfoCTI` only accepts integers.

This was only an issue on my Mac with python 3.6.3, the visual machine, running python 2.7.1 does not have this issue and `num_views` is an int.

I have resolved this issue by forcing `num_views` to be type int.