### PR TITLE
add .devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+/// format: https://aka.ms/devcontainer.json
+{
+"hostRequirements": {
+	"cpus": 2,
+	"memory": "8gb",
+	"storage": "32gb"
+},
+"name": "STIR-Exercises (CPU)",
+//"initializeCommand": "docker system prune --all --force",
+"image": "mcr.microsoft.com/devcontainers/anaconda",
+"postCreateCommand": "bash ./requirements.sh",
+//"postStartCommand": "nohup bash -c 'jupyter notebook --ip=0.0.0.0 --port=8888 --allow-root &'",
+"remoteUser": "vscode",
+"portsAttributes": {"8888": {"label": "Jupyter", "onAutoForward": "ignore"}},
+// "features": {}, // https://containers.dev/features
+"customizations": {"vscode": {"extensions": [
+	"ms-python.python",
+	"ms-toolsai.jupyter",
+	"ms-python.vscode-pylance"]}}
+}

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,14 @@
+channels:
+  - conda-forge
+dependencies:
+  - setuptools
+  - wheel
+  - pip
+  - pytest
+  - stir
+  - matplotlib
+  - zenodo_get
+  - jupyterlab_widgets
+  - ipywidgets>=8
+  - ipympl
+

--- a/requirements.sh
+++ b/requirements.sh
@@ -1,3 +1,4 @@
 #!/bin/sh -e
-
+apt-get update
+export DEBIAN_FRONTEND=noninteractive
 apt-get install tcsh rsync


### PR DESCRIPTION
Attempt to add a devcontainer for VS Code and Github Codespaces etc.

I'm trying to use https://github.com/devcontainers/images/tree/main/src/anaconda and the conda-forge version of STIR.